### PR TITLE
Add composer package type to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "alleyinteractive/fm-widgets",
+  "type": "wordpress-plugin",
   "authors": [
     {
       "name": "Matthew Boynes",


### PR DESCRIPTION
Lets us use `type:wordpress-plugin` location